### PR TITLE
add context-aware track playback

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing to Spotifly
+
+## Librespot Fork Requirement
+
+This project uses a **modified fork of librespot**, not the official repository.
+
+| Repository | URL | Status |
+|------------|-----|--------|
+| Official librespot | `github.com/librespot-org/librespot` | Will NOT work |
+| Required fork | `github.com/ralph/librespot` | Required |
+
+The fork adds `PlayerEvent::SetQueue` and `QueueTrack` types for queue state updates. Using the official librespot will cause build errors.
+
+## Setup
+
+Clone the fork as a sibling to this repository:
+
+```bash
+git clone https://github.com/ralph/librespot.git
+```
+
+Expected directory structure:
+```
+YourProjects/
+├── Spotifly/       # This repo
+└── librespot/      # Ralph's fork
+```
+
+Then build Rust (`cd rust && ./build.sh`) and open Xcode.

--- a/Spotifly/SpotifyPlayer.swift
+++ b/Spotifly/SpotifyPlayer.swift
@@ -801,12 +801,15 @@ enum SpotifyPlayer {
     }
 
     /// Plays content by its Spotify URI or URL.
-    /// Supports tracks, albums, playlists, and artists.
+    /// Supports albums, playlists, and artists (context URIs).
+    /// - Parameters:
+    ///   - uriOrUrl: Spotify URI or URL (e.g., "spotify:album:xxx")
+    ///   - trackIndex: Track index to start at (-1 = from beginning, 0+ = specific track)
     @SpotifyAuthActor
-    static func play(uriOrUrl: String) async throws {
+    static func play(uriOrUrl: String, trackIndex: Int = -1) async throws {
         let result = await Task.detached {
             uriOrUrl.withCString { ptr in
-                spotifly_play_uri(ptr)
+                spotifly_play_uri(ptr, Int32(trackIndex))
             }
         }.value
 

--- a/Spotifly/ViewModels/PlaybackViewModel.swift
+++ b/Spotifly/ViewModels/PlaybackViewModel.swift
@@ -155,7 +155,7 @@ final class PlaybackViewModel {
         isLoading = false
     }
 
-    func play(uriOrUrl: String, accessToken: String) async {
+    func play(uriOrUrl: String, trackIndex: Int = -1, accessToken: String) async {
         // Initialize if needed
         if !isInitialized {
             await initializeIfNeeded(accessToken: accessToken)
@@ -170,7 +170,7 @@ final class PlaybackViewModel {
         errorMessage = nil
 
         do {
-            try await SpotifyPlayer.play(uriOrUrl: uriOrUrl)
+            try await SpotifyPlayer.play(uriOrUrl: uriOrUrl, trackIndex: trackIndex)
             handlePlaybackStarted(trackId: uriOrUrl)
         } catch {
             errorMessage = error.localizedDescription

--- a/Spotifly/Views/AlbumDetailView.swift
+++ b/Spotifly/Views/AlbumDetailView.swift
@@ -217,6 +217,8 @@ struct AlbumDetailView: View {
                                 playbackViewModel: playbackViewModel,
                                 currentSection: .albums,
                                 selectionId: albumId,
+                                contextUri: album.uri,
+                                trackIndexInContext: index,
                             )
 
                             if index < tracks.count - 1 {

--- a/Spotifly/Views/ArtistDetailView.swift
+++ b/Spotifly/Views/ArtistDetailView.swift
@@ -188,6 +188,8 @@ struct ArtistDetailView: View {
                                     playbackViewModel: playbackViewModel,
                                     currentSection: .artists,
                                     selectionId: artistId,
+                                    contextUri: artist.uri,
+                                    trackIndexInContext: index,
                                 )
 
                                 if track.id != displayedTracks.last?.id {

--- a/Spotifly/Views/Components/TrackCard.swift
+++ b/Spotifly/Views/Components/TrackCard.swift
@@ -78,9 +78,7 @@ struct TrackCard: View {
     }
 
     private func playTrack() {
-        Task {
-            let token = await session.validAccessToken()
-            await playbackViewModel.playTracks([track.uri], accessToken: token)
-        }
+        // Start radio for the track (search result cards don't have context)
+        SpotifyPlayer.playRadio(trackUri: track.uri)
     }
 }

--- a/Spotifly/Views/FavoritesListView.swift
+++ b/Spotifly/Views/FavoritesListView.swift
@@ -63,6 +63,8 @@ struct FavoritesListView: View {
                                 currentlyPlayingURI: playbackViewModel.currentlyPlayingURI,
                                 playbackViewModel: playbackViewModel,
                                 currentSection: .favorites,
+                                contextUri: "spotify:collection:tracks",
+                                trackIndexInContext: index,
                             )
 
                             if index < store.favoriteTracks.count - 1 {

--- a/Spotifly/Views/PlaylistDetailView.swift
+++ b/Spotifly/Views/PlaylistDetailView.swift
@@ -300,6 +300,8 @@ struct PlaylistDetailView: View {
             playbackViewModel: playbackViewModel,
             currentSection: .playlists,
             selectionId: playlistId,
+            contextUri: playlist?.uri,
+            trackIndexInContext: index,
         )
 
         if isOwner {

--- a/Spotifly/Views/QueueListView.swift
+++ b/Spotifly/Views/QueueListView.swift
@@ -219,6 +219,7 @@ struct QueueListView: View {
                             playbackViewModel: playbackViewModel,
                             doubleTapBehavior: .playTrack,
                             currentSection: .queue,
+                            trackIndexInContext: index,
                         )
                         .id(index)
 

--- a/Spotifly/Views/TrackRow.swift
+++ b/Spotifly/Views/TrackRow.swift
@@ -24,6 +24,8 @@ struct TrackRow: View {
     let doubleTapBehavior: TrackRowDoubleTapBehavior
     let currentSection: NavigationItem // Current sidebar section (for "Go to" navigation)
     let selectionId: String? // Current selection ID (e.g., playlist ID) for back navigation
+    let contextUri: String? // Album/playlist/artist URI for context-aware playback
+    let trackIndexInContext: Int? // Index within the context for starting playback
 
     @Environment(NavigationCoordinator.self) private var navigationCoordinator
     @Environment(SpotifySession.self) private var session
@@ -68,6 +70,8 @@ struct TrackRow: View {
         doubleTapBehavior: TrackRowDoubleTapBehavior = .playTrack,
         currentSection: NavigationItem = .startpage,
         selectionId: String? = nil,
+        contextUri: String? = nil,
+        trackIndexInContext: Int? = nil,
     ) {
         self.track = track
         self.showTrackNumber = showTrackNumber
@@ -83,6 +87,8 @@ struct TrackRow: View {
         self.doubleTapBehavior = doubleTapBehavior
         self.currentSection = currentSection
         self.selectionId = selectionId
+        self.contextUri = contextUri
+        self.trackIndexInContext = trackIndexInContext
     }
 
     var body: some View {
@@ -242,10 +248,33 @@ struct TrackRow: View {
         case .playTrack:
             Task {
                 let token = await session.validAccessToken()
-                await playbackViewModel.play(
-                    uriOrUrl: track.uri,
-                    accessToken: token,
-                )
+
+                // Context-aware playback: if we have a context URI and track index, use them
+                if let contextUri, let index = trackIndexInContext {
+                    await playbackViewModel.play(
+                        uriOrUrl: contextUri,
+                        trackIndex: index,
+                        accessToken: token,
+                    )
+                } else if currentSection == .queue {
+                    // Queue: skip to this track within current context
+                    if let queueContextUri = store.queue.contextUri, let index = trackIndexInContext {
+                        await playbackViewModel.play(
+                            uriOrUrl: queueContextUri,
+                            trackIndex: index,
+                            accessToken: token,
+                        )
+                    }
+                } else if currentSection == .searchResults {
+                    // Search results: start radio for the track
+                    SpotifyPlayer.playRadio(trackUri: track.uri)
+                } else {
+                    // Fallback: single track playback (legacy behavior)
+                    await playbackViewModel.play(
+                        uriOrUrl: track.uri,
+                        accessToken: token,
+                    )
+                }
             }
         }
     }

--- a/rust/include/spotifly_rust.h
+++ b/rust/include/spotifly_rust.h
@@ -44,9 +44,11 @@ int32_t spotifly_init_player(const char* access_token);
 int32_t spotifly_play_tracks(const char* track_uris_json);
 
 /// Plays content by its Spotify URI or URL.
-/// Supports tracks, albums, playlists, and artists.
+/// Supports albums, playlists, and artists (context URIs).
+/// @param uri_or_url Spotify URI or URL (e.g., "spotify:album:xxx")
+/// @param track_index Track index to start at (-1 = from beginning, 0+ = specific track)
 /// Returns 0 on success, -1 on error.
-int32_t spotifly_play_uri(const char* uri_or_url);
+int32_t spotifly_play_uri(const char* uri_or_url, int32_t track_index);
 
 /// Pauses playback.
 /// Returns 0 on success, -1 on error, -2 if session disconnected.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,7 +1,7 @@
 mod proxy_sink;
 
 use futures_util::StreamExt;
-use librespot_connect::{ConnectConfig, LoadRequest, LoadRequestOptions, Spirc};
+use librespot_connect::{ConnectConfig, LoadRequest, LoadRequestOptions, PlayingTrack, Spirc};
 use librespot_core::cache::Cache;
 use librespot_core::config::DeviceType;
 use librespot_core::session::Session;
@@ -1727,10 +1727,12 @@ pub extern "C" fn spotifly_play_tracks(track_uris_json: *const c_char) -> i32 {
 }
 
 /// Plays content by its Spotify URI or URL.
-/// Supports tracks, albums, playlists, and artists.
+/// Supports albums, playlists, and artists (context URIs).
+/// @param uri_or_url Spotify URI or URL (e.g., "spotify:album:xxx")
+/// @param track_index Track index to start at (-1 = from beginning, 0+ = specific track)
 /// Returns 0 on success, -1 on error.
 #[no_mangle]
-pub extern "C" fn spotifly_play_uri(uri_or_url: *const c_char) -> i32 {
+pub extern "C" fn spotifly_play_uri(uri_or_url: *const c_char, track_index: i32) -> i32 {
     if uri_or_url.is_null() {
         debug!("Play error: uri_or_url is null");
         return -1;
@@ -1748,7 +1750,7 @@ pub extern "C" fn spotifly_play_uri(uri_or_url: *const c_char) -> i32 {
 
     // Convert URL to URI if needed
     let uri_str = url_to_uri(&input_str);
-    debug!("spotifly_play_uri called: {}", uri_str);
+    debug!("spotifly_play_uri called: uri={}, track_index={}", uri_str, track_index);
 
     if let Err(e) = require_session_connected() {
         return e;
@@ -1763,9 +1765,17 @@ pub extern "C" fn spotifly_play_uri(uri_or_url: *const c_char) -> i32 {
                 return e;
             }
 
+            // Determine playing_track option based on track_index
+            let playing_track = if track_index >= 0 {
+                Some(PlayingTrack::Index(track_index as u32))
+            } else {
+                None
+            };
+
             // Create LoadRequest - use from_context_uri for albums/playlists/artists,
-            // from_tracks for single tracks
+            // from_tracks for single tracks (legacy behavior, prefer using radio for tracks)
             let load_request = if uri_str.starts_with("spotify:track:") {
+                // Legacy single-track behavior - prefer using spotifly_play_radio instead
                 debug!("Spirc.load(LoadRequest::from_tracks([{}]))", uri_str);
                 LoadRequest::from_tracks(
                     vec![uri_str.clone()],
@@ -1776,12 +1786,17 @@ pub extern "C" fn spotifly_play_uri(uri_or_url: *const c_char) -> i32 {
                     },
                 )
             } else {
-                debug!("Spirc.load(LoadRequest::from_context_uri({}))", uri_str);
+                // Context-based playback with optional starting track
+                debug!(
+                    "Spirc.load(LoadRequest::from_context_uri({}, playing_track={:?}))",
+                    uri_str, playing_track
+                );
                 LoadRequest::from_context_uri(
                     uri_str.clone(),
                     LoadRequestOptions {
                         start_playing: true,
                         seek_to: 0,
+                        playing_track,
                         ..Default::default()
                     },
                 )


### PR DESCRIPTION
implements context-aware track playback: double-tapping a track in album, playlist, or artist views now plays the full context from that position rather than the single track. 
search results initiate radio playback

 adds CONTRIBUTING.md to document the librespot fork dependency