### PR TITLE
Reduce seek bar update frequency for lower CPU usage

### DIFF
--- a/Spotifly/Views/NowPlayingBarView.swift
+++ b/Spotifly/Views/NowPlayingBarView.swift
@@ -274,8 +274,8 @@ struct NowPlayingBarView: View {
     }
 
     private var progressBar: some View {
-        // TimelineView updates at display refresh rate for smooth slider
-        TimelineView(.animation(minimumInterval: 0.033)) { _ in
+        // Lower frame rate when not hovering: 10 FPS on hover, 1 FPS otherwise
+        TimelineView(.animation(minimumInterval: isHoveringSeekBar ? 0.1 : 1.0)) { _ in
             HStack(spacing: 8) {
                 // Show timestamp only on hover
                 if isHoveringSeekBar {


### PR DESCRIPTION
## Changes

- Modified `TimelineView` in `NowPlayingBarView` to use adaptive update frequency based on hover state
- When hovering over seek bar: 10 FPS (0.1s minimum interval)
- When not hovering: 1 FPS (1.0s minimum interval)
- Reduces unnecessary CPU overhead during normal playback while maintaining smooth interaction on hover