### PR TITLE
Fix Now Playing menu bar overlay not updating on auto-advance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored the logged-in shell so `NavigationCoordinator` now owns section selection, library detail selection, drill-down path, and back/forward history, with toolbar, lifecycle, and column routing extracted out of `LoggedInView`
 
 ### Fixed
+- Fixed the Now Playing overlay (menu bar) not updating when a song auto-advances during album/playlist playback
 - Favorites now resolve via batched `/me/tracks/contains` checks for the tracks actually shown in album, playlist, queue, search, and now-playing views instead of depending on a full favorites preload
 - Saving and removing favorite tracks now uses Spotify's saved-tracks endpoint correctly, so heart toggles persist again across Spotify clients
 - Clicking Favorites in the sidebar now loads the favorites list automatically again, and the first real favorites fetch replaces any optimistic placeholder entries instead of appending to them

--- a/Spotifly/ViewModels/PlaybackViewModel.swift
+++ b/Spotifly/ViewModels/PlaybackViewModel.swift
@@ -55,6 +55,7 @@ final class PlaybackViewModel {
     var isPlaying = false
     var isLoading = false
     var currentTrackUri: String?
+    private var lastHandledTrackUri: String?
     var errorMessage: String?
 
     /// Returns the URI of the currently playing track (alias for currentTrackUri)
@@ -155,6 +156,7 @@ final class PlaybackViewModel {
         isPlaying = false
         updateNowPlayingPosition()
         currentTrackUri = nil
+        lastHandledTrackUri = nil
         trackDurationMs = 0
         currentPositionMs = 0
         positionAnchorMs = 0
@@ -261,6 +263,7 @@ final class PlaybackViewModel {
     /// Common setup after playback has started
     private func handlePlaybackStarted(trackId: String) {
         currentTrackUri = trackId
+        lastHandledTrackUri = trackId
         isPlaying = true
         // Apply volume after playback starts (mixer is now initialized)
         SpotifyPlayer.setVolume(volume)
@@ -287,6 +290,7 @@ final class PlaybackViewModel {
         SpotifyPlayer.stop()
         isPlaying = false
         currentTrackUri = nil
+        lastHandledTrackUri = nil
     }
 
     /// Sets the AppStore reference. Call this after AppStore is created.
@@ -699,6 +703,11 @@ final class PlaybackViewModel {
         isPlaying = newIsPlaying
 
         // Update track if changed
+        let trackChanged = !state.trackUri.isEmpty && state.trackUri != lastHandledTrackUri
+        if trackChanged {
+            lastHandledTrackUri = state.trackUri
+        }
+
         if !state.trackUri.isEmpty, state.trackUri != currentTrackUri {
             currentTrackUri = state.trackUri
             // Note: Track metadata (name, artist, etc.) will be updated from queue
@@ -735,8 +744,10 @@ final class PlaybackViewModel {
             currentPositionMs = posMs
         }
 
-        // Update Now Playing position if playback rate changed
-        if wasPlaying != isPlaying {
+        // Update Now Playing position if playback rate changed, or if track changed
+        if trackChanged {
+            updateNowPlayingInfo()
+        } else if wasPlaying != isPlaying {
             updateNowPlayingPosition()
         }
     }
@@ -763,6 +774,7 @@ final class PlaybackViewModel {
         // Update track if provided
         if let uri = trackUri, !uri.isEmpty {
             currentTrackUri = uri
+            lastHandledTrackUri = uri
         }
 
         // Update duration


### PR DESCRIPTION
Fixes #39.

Updates the macOS system Control Center / menu bar Now Playing overlay metadata and seekbar during auto-advance transitions.

    ### Changes
    - Introduced `lastHandledTrackUri` in `PlaybackViewModel` to track when full playback state updates
  transition tracks.
    - Triggered `updateNowPlayingInfo()` on track changes in `handlePlaybackStateUpdate` to propagate
  changes to `MPNowPlayingInfoCenter` immediately.
    - Updated `CHANGELOG.md` accordingly.