### PR TITLE
Fix song radio start position for current track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored the logged-in shell so `NavigationCoordinator` now owns section selection, library detail selection, drill-down path, and back/forward history, with toolbar, lifecycle, and column routing extracted out of `LoggedInView`
 
 ### Fixed
+- Starting song radio from the currently playing track now seeks with the same interpolated playback position the UI uses, avoiding stale-position jumps when the radio context loads
 - Favorites now resolve via batched `/me/tracks/contains` checks for the tracks actually shown in album, playlist, queue, search, and now-playing views instead of depending on a full favorites preload
 - Saving and removing favorite tracks now uses Spotify's saved-tracks endpoint correctly, so heart toggles persist again across Spotify clients
 - Clicking Favorites in the sidebar now loads the favorites list automatically again, and the first real favorites fetch replaces any optimistic placeholder entries instead of appending to them

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2481,8 +2481,7 @@ pub extern "C" fn spotifly_is_active_device() -> i32 {
 /// Returns the current playback position in milliseconds.
 /// If playing, interpolates from last known position.
 /// Returns 0 if not playing or no position available.
-#[no_mangle]
-pub extern "C" fn spotifly_get_position_ms() -> u32 {
+fn current_position_ms() -> u32 {
     let stored_position = POSITION_MS.load(Ordering::SeqCst);
     let stored_timestamp = POSITION_TIMESTAMP_MS.load(Ordering::SeqCst);
 
@@ -2501,6 +2500,11 @@ pub extern "C" fn spotifly_get_position_ms() -> u32 {
     } else {
         stored_position
     }
+}
+
+#[no_mangle]
+pub extern "C" fn spotifly_get_position_ms() -> u32 {
+    current_position_ms()
 }
 
 /// Skips to the next track in the queue.
@@ -2638,7 +2642,14 @@ async fn play_radio_async(uri_str: &str) -> i32 {
         }
     };
 
-    debug!("Loading radio playlist: {}", playlist_uri);
+    let current_track_uri = CURRENT_TRACK_URI.lock().unwrap().clone();
+    let seek_to = if current_track_uri.as_deref() == Some(uri_str) {
+        current_position_ms()
+    } else {
+        0
+    };
+
+    debug!("Loading radio playlist: {} at {}ms", playlist_uri, seek_to);
 
     let spirc_guard = SPIRC.lock().unwrap();
     match spirc_guard.as_ref() {
@@ -2651,7 +2662,7 @@ async fn play_radio_async(uri_str: &str) -> i32 {
                 playlist_uri.clone(),
                 LoadRequestOptions {
                     start_playing: true,
-                    seek_to: 0,
+                    seek_to,
                     playing_track: Some(PlayingTrack::Uri(uri_str.to_string())),
                     ..Default::default()
                 },


### PR DESCRIPTION
## Summary
- Preserve the current interpolated playback position when starting song radio from the currently playing track
- Keep non-current-track radio starts beginning at `0ms`
- Add an Unreleased changelog entry for the radio positioning fix

## Testing
- Built successfully with:
  `xcodebuild -project Spotifly.xcodeproj -scheme Spotifly -configuration Debug -destination 'platform=macOS' -derivedDataPath /private/tmp/spotifly-derived CODE_SIGNING_ALLOWED=NO build`
